### PR TITLE
Annotation toolbar customisation

### DIFF
--- a/android/src/main/java/com/pspdfkit/flutter/pspdfkit/CustomAnnotationToolbarMenu.kt
+++ b/android/src/main/java/com/pspdfkit/flutter/pspdfkit/CustomAnnotationToolbarMenu.kt
@@ -1,0 +1,15 @@
+package com.pspdfkit.flutter.pspdfkit
+
+import android.content.Context
+import com.pspdfkit.ui.toolbar.ContextualToolbar
+import com.pspdfkit.ui.toolbar.grouping.presets.MenuItem
+import com.pspdfkit.ui.toolbar.grouping.presets.PresetMenuItemGroupingRule
+
+class CustomAnnotationToolbarMenu(context: Context) : PresetMenuItemGroupingRule(context) {
+    override fun getGroupPreset(capacity: Int, itemsCount: Int): List<MenuItem> {
+        return  listOf(
+            MenuItem(com.pspdfkit.R.id.pspdf__annotation_creation_toolbar_item_highlight),
+            MenuItem(com.pspdfkit.R.id.pspdf__annotation_creation_toolbar_item_underline)
+        )
+    }
+}

--- a/android/src/main/java/com/pspdfkit/flutter/pspdfkit/FlutterPdfUiFragment.kt
+++ b/android/src/main/java/com/pspdfkit/flutter/pspdfkit/FlutterPdfUiFragment.kt
@@ -1,14 +1,26 @@
 package com.pspdfkit.flutter.pspdfkit
 
+import android.os.Bundle
+import android.view.View
 import com.pspdfkit.annotations.measurements.FloatPrecision
 import com.pspdfkit.annotations.measurements.Scale
 import com.pspdfkit.document.PdfDocument
 import com.pspdfkit.ui.PdfUiFragment
+import com.pspdfkit.ui.toolbar.AnnotationCreationToolbar
+import com.pspdfkit.ui.toolbar.ContextualToolbar
+import com.pspdfkit.ui.toolbar.ToolbarCoordinatorLayout
+import java.util.EnumSet
 
-class FlutterPdfUiFragment : PdfUiFragment() {
+class FlutterPdfUiFragment : PdfUiFragment(),
+    ToolbarCoordinatorLayout.OnContextualToolbarLifecycleListener {
 
     private var scale: Scale? = null
     private var precision: FloatPrecision? = null
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setOnContextualToolbarLifecycleListener(this)
+    }
 
     override fun onDocumentLoaded(document: PdfDocument) {
         super.onDocumentLoaded(document)
@@ -29,6 +41,21 @@ class FlutterPdfUiFragment : PdfUiFragment() {
 
     fun setMeasurementPrecision(precision: FloatPrecision?) {
         this.precision = precision
+    }
+
+    override fun onPrepareContextualToolbar(toolbar: ContextualToolbar<*>) {
+        if (toolbar is AnnotationCreationToolbar) {
+            toolbar.setMenuItemGroupingRule(CustomAnnotationToolbarMenu(requireContext()))
+            toolbar.layoutParams = ToolbarCoordinatorLayout.LayoutParams(
+                ToolbarCoordinatorLayout.LayoutParams.Position.TOP, EnumSet.of(ToolbarCoordinatorLayout.LayoutParams.Position.TOP)
+            )
+        }
+    }
+
+    override fun onDisplayContextualToolbar(p0: ContextualToolbar<*>) {
+    }
+
+    override fun onRemoveContextualToolbar(p0: ContextualToolbar<*>) {
     }
 
 }

--- a/ios/Classes/PspdfPlatformView.m
+++ b/ios/Classes/PspdfPlatformView.m
@@ -95,6 +95,15 @@
         [_channel setMethodCallHandler:^(FlutterMethodCall * _Nonnull call, FlutterResult  _Nonnull result) {
             [weakSelf handleMethodCall:call result:result];
         }];
+
+        PSPDFAnnotationToolbarConfiguration *configuration = [[PSPDFAnnotationToolbarConfiguration alloc] initWithAnnotationGroups:@[
+            [PSPDFAnnotationGroup groupWithItems:@[
+                [PSPDFAnnotationGroupItem itemWithType:PSPDFAnnotationStringHighlight],
+                [PSPDFAnnotationGroupItem itemWithType:PSPDFAnnotationStringUnderline]
+            ]]
+        ]];
+        
+        _pdfViewController.annotationToolbarController.annotationToolbar.configurations = @[configuration];
     }
 
     return self;


### PR DESCRIPTION

# ONLY FOR DEMONSTRATION

This is a demonstration of how we can natively customise the annotation toolbar in PSPDFKit for Futter.
For more details on how to customise annotation toolbar natively, please refer to the following links:
- iOS: https://pspdfkit.com/guides/ios/customizing-the-interface/customizing-the-annotation-toolbar/#annotation-buttons
- Android: https://pspdfkit.com/guides/android/customizing-the-interface/customizing-the-toolbar/#change-the-grouping-of-toolbar-items
 

