### PR TITLE
Demo - Disable file coordination

### DIFF
--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -44,13 +44,13 @@ PSPDFSettingKey const PSPDFSettingKeyHybridEnvironment = @"com.pspdfkit.hybrid-e
         if ([licenseKey isKindOfClass:[NSNull class]]|| licenseKey.length <= 0) {
             return;
         }
-        [PSPDFKitGlobal setLicenseKey:licenseKey options:@{PSPDFSettingKeyHybridEnvironment: @"Flutter"}];
+        [PSPDFKitGlobal setLicenseKey:licenseKey options:@{PSPDFSettingKeyHybridEnvironment: @"Flutter", PSPDFSettingKeyFileCoordinationEnabled: @false}];
     } else if ([@"setLicenseKeys" isEqualToString:call.method]) {
         NSString *iOSLicenseKey = call.arguments[@"iOSLicenseKey"];
         if ([iOSLicenseKey isKindOfClass:[NSNull class]]|| iOSLicenseKey.length <= 0) {
             return;
         }
-        [PSPDFKitGlobal setLicenseKey:iOSLicenseKey options:@{PSPDFSettingKeyHybridEnvironment: @"Flutter"}];
+        [PSPDFKitGlobal setLicenseKey:iOSLicenseKey options:@{PSPDFSettingKeyHybridEnvironment: @"Flutter", PSPDFSettingKeyFileCoordinationEnabled: @false}];
     }else if ([@"present" isEqualToString:call.method]) {
         
         NSString *documentPath = call.arguments[@"document"];


### PR DESCRIPTION
# ⚠️ DO NOT MERGE


# Details
This is a demo for disabling file coordination for iOS which will stop the file conflict popup dialog from showing up.
