### PR TITLE
Custom stamps demo code

### DIFF
--- a/android/src/main/java/com/pspdfkit/flutter/pspdfkit/FlutterPdfUiFragment.kt
+++ b/android/src/main/java/com/pspdfkit/flutter/pspdfkit/FlutterPdfUiFragment.kt
@@ -16,6 +16,11 @@ package com.pspdfkit.flutter.pspdfkit
 ///  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
 ///  This notice may not be removed from this file.
 ///
+import android.os.Bundle
+import android.view.View
+import com.pspdfkit.annotations.AnnotationType
+import com.pspdfkit.annotations.configuration.StampAnnotationConfiguration
+import com.pspdfkit.annotations.stamps.StampPickerItem
 import com.pspdfkit.document.PdfDocument
 import com.pspdfkit.ui.PdfUiFragment
 
@@ -25,5 +30,18 @@ class FlutterPdfUiFragment : PdfUiFragment() {
         super.onDocumentLoaded(document)
       // Notify the Flutter PSPDFKit plugin that the document has been loaded.
         EventDispatcher.getInstance().notifyDocumentLoaded(document)
+        val items = listOf(
+            StampPickerItem.fromTitle(requireContext(), "Great!").build(),
+            StampPickerItem.fromTitle(requireContext(), "Stamp!").build(),
+            StampPickerItem.fromTitle(requireContext(), "Like").build()
+        )
+        // Available stamps can be configured through the `PdfFragment`.
+        requirePdfFragment().annotationConfiguration.put(
+            AnnotationType.STAMP,
+            StampAnnotationConfiguration.builder(requireContext())
+                // Here you set the list of stamp picker items that are going to be available in the stamp picker.
+                .setAvailableStampPickerItems(items)
+                .build()
+        )
     }
 }

--- a/ios/Classes/PspdfkitPlatformViewImpl.swift
+++ b/ios/Classes/PspdfkitPlatformViewImpl.swift
@@ -355,6 +355,17 @@ public class PspdfkitPlatformViewImpl: NSObject, PspdfkitWidgetControllerApi, PD
                                                selector: #selector(spreadIndexDidChange(_:)),
                                                name: .PSPDFDocumentViewControllerSpreadIndexDidChange,
                                                object: nil)
+        
+        var stamps = [StampAnnotation]()
+        let stampNames = ["Great!", "Stamp", "Like"]
+
+        for name in stampNames {
+            let stampAnnotation = StampAnnotation(title: name.uppercased())
+            let suggestedSize = stampAnnotation.sizeThatFits(CGSize(width: 200, height: 100))
+            stampAnnotation.boundingBox = CGRect(x: 0, y: 0, width: suggestedSize.width, height: suggestedSize.height)
+            stamps.append(stampAnnotation)
+        }
+        StampViewController.defaultStampAnnotations = stamps
     }
     
     @objc public func unRegister(binaryMessenger: FlutterBinaryMessenger){


### PR DESCRIPTION
# Details
This pull request introduces enhancements to the `FlutterPdfUiFragment` class on Android and the `PspdfkitPlatformViewImpl` class on iOS to support custom stamp annotations. The most important changes include configuring stamp picker items on Android, and setting default stamp annotations on iOS.

Related native guides:
Android - https://www.nutrient.io/guides/android/annotations/stamp-annotations-configuration/
iOS - https://www.nutrient.io/guides/ios/annotations/stamp-annotations-configuration/

