### PR TITLE
hide delete button based on annotation custom  data

### DIFF
--- a/android/src/main/java/com/pspdfkit/flutter/pspdfkit/FlutterPdfUiFragment.kt
+++ b/android/src/main/java/com/pspdfkit/flutter/pspdfkit/FlutterPdfUiFragment.kt
@@ -33,7 +33,7 @@ import com.pspdfkit.ui.PdfUiFragment
 import com.pspdfkit.ui.toolbar.ContextualToolbar
 import com.pspdfkit.ui.toolbar.ToolbarCoordinatorLayout
 import com.pspdfkit.annotations.Annotation
-import com.pspdfkit.R
+
 
 class FlutterPdfUiFragment : PdfUiFragment(), MenuProvider, ToolbarCoordinatorLayout.OnContextualToolbarLifecycleListener {
 
@@ -313,9 +313,17 @@ class FlutterPdfUiFragment : PdfUiFragment(), MenuProvider, ToolbarCoordinatorLa
     }
 
     /**
-     * Helper method to determine if the delete button should be hidden based on annotation custom data.
+     * Helper method to determine if annotation modification actions should be hidden based on annotation custom data.
      * 
-     * @return True if delete button should be hidden, false otherwise
+     * When annotations have 'hideDelete': true in their customData, this will hide all modification options
+     * including delete, edit, copy, cut, style picker, inspector, etc.
+     * 
+     * References:
+     * - Android Contextual Toolbars: https://www.nutrient.io/guides/android/customizing-the-interface/customizing-the-toolbar/
+     * - Annotation Custom Data: https://www.nutrient.io/guides/android/annotations/annotation-json/
+     * - ContextualToolbar API: https://www.nutrient.io/api/android/kdoc/pspdfkit/com.pspdfkit.ui.toolbar/-contextual-toolbar/
+     * 
+     * @return True if modification actions should be hidden, false otherwise
      */
     private fun shouldHideDeleteButton(): Boolean {
         try {
@@ -344,10 +352,18 @@ class FlutterPdfUiFragment : PdfUiFragment(), MenuProvider, ToolbarCoordinatorLa
         val shouldHideDelete = shouldHideDeleteButton()
         
         if (shouldHideDelete) {
-            toolbar.setMenuItemVisibility(
-                R.id.pspdf__annotation_editing_toolbar_item_delete,
-                View.GONE
-            )
+            // Hide all modification actions for protected annotations
+            // Reference: Complete list of annotation editing menu item IDs can be found in Android resources
+            // See: https://www.nutrient.io/guides/android/customizing-the-interface/customizing-the-toolbar/
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_delete, View.GONE)        // Delete annotation
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_cut, View.GONE)           // Cut annotation to clipboard
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_copy, View.GONE)          // Copy annotation to clipboard
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_edit, View.GONE)          // Edit annotation content
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_picker, View.GONE)        // Style/appearance picker
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_annotation_note, View.GONE) // Edit annotation notes
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_inspector, View.GONE)                  // Properties inspector
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_group, View.GONE)         // Group annotations
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_ungroup, View.GONE)       // Ungroup annotations
         }
     }
 
@@ -356,10 +372,18 @@ class FlutterPdfUiFragment : PdfUiFragment(), MenuProvider, ToolbarCoordinatorLa
         val shouldHideDelete = shouldHideDeleteButton()
         
         if (shouldHideDelete) {
-            toolbar.setMenuItemVisibility(
-                R.id.pspdf__annotation_editing_toolbar_item_delete,
-                View.GONE
-            )
+            // Hide all modification actions for protected annotations
+            // Reference: Complete list of annotation editing menu item IDs can be found in Android resources
+            // See: https://www.nutrient.io/guides/android/customizing-the-interface/customizing-the-toolbar/
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_delete, View.GONE)        // Delete annotation
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_cut, View.GONE)           // Cut annotation to clipboard
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_copy, View.GONE)          // Copy annotation to clipboard
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_edit, View.GONE)          // Edit annotation content
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_picker, View.GONE)        // Style/appearance picker
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_annotation_note, View.GONE) // Edit annotation notes
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_inspector, View.GONE)                  // Properties inspector
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_group, View.GONE)         // Group annotations
+            toolbar.setMenuItemVisibility(R.id.pspdf__annotation_editing_toolbar_item_ungroup, View.GONE)       // Ungroup annotations
         }
     }
 

--- a/example/lib/examples.dart
+++ b/example/lib/examples.dart
@@ -112,9 +112,9 @@ List<NutrientExampleItem> examples(BuildContext context) => [
         onTap: () => annotationsExample(context),
       ),
       NutrientExampleItem(
-        title: 'Hide Annotation Modification Options',
+        title: 'Protected Annotations (Move Only)',
         description:
-            'Demonstrates how to use custom data to conditionally hide all modification options (delete, edit, copy, cut, style picker, etc.) on annotations.',
+            'Demonstrates how to create protected annotations that can be moved but not edited or resized. Uses custom data to disable contextual menus while preserving movement functionality.',
         onTap: () => hideDeleteAnnotationExample(context),
       ),
       NutrientExampleItem(

--- a/example/lib/examples.dart
+++ b/example/lib/examples.dart
@@ -112,9 +112,9 @@ List<NutrientExampleItem> examples(BuildContext context) => [
         onTap: () => annotationsExample(context),
       ),
       NutrientExampleItem(
-        title: 'Hide Delete Button on Annotations',
+        title: 'Hide Annotation Modification Options',
         description:
-            'Demonstrates how to use custom data to conditionally hide delete buttons on annotations.',
+            'Demonstrates how to use custom data to conditionally hide all modification options (delete, edit, copy, cut, style picker, etc.) on annotations.',
         onTap: () => hideDeleteAnnotationExample(context),
       ),
       NutrientExampleItem(

--- a/example/lib/examples.dart
+++ b/example/lib/examples.dart
@@ -42,6 +42,7 @@ import 'manual_save_example.dart';
 import 'annotation_processing_example.dart';
 import 'password_example.dart';
 import 'nutrient_annotation_creation_mode_example.dart';
+import 'hide_delete_annotation_example.dart';
 
 const String _documentPath = 'PDFs/PSPDFKit.pdf';
 const String _measurementsDocs = 'PDFs/Measurements.pdf';
@@ -109,6 +110,12 @@ List<NutrientExampleItem> examples(BuildContext context) => [
         description:
             'Programmatically adds and removes annotations using a custom Widget.',
         onTap: () => annotationsExample(context),
+      ),
+      NutrientExampleItem(
+        title: 'Hide Delete Button on Annotations',
+        description:
+            'Demonstrates how to use custom data to conditionally hide delete buttons on annotations.',
+        onTap: () => hideDeleteAnnotationExample(context),
       ),
       NutrientExampleItem(
         title: 'Annotation Flags Example',
@@ -613,4 +620,11 @@ void annotationFlagsExample(BuildContext context) {
     const AnnotationFlagsExample(),
     context,
   );
+}
+
+void hideDeleteAnnotationExample(BuildContext context) async {
+  final extractedDocument = await extractAsset(context, _documentPath);
+  await Navigator.of(context).push<dynamic>(MaterialPageRoute<dynamic>(
+      builder: (_) => HideDeleteAnnotationExampleWidget(
+          documentPath: extractedDocument.path)));
 }

--- a/example/lib/hide_delete_annotation_example.dart
+++ b/example/lib/hide_delete_annotation_example.dart
@@ -1,0 +1,273 @@
+///
+///  Copyright @ 2018-2025 PSPDFKit GmbH. All rights reserved.
+///
+///  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+///  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+///  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+///  This notice may not be removed from this file.
+///
+/// ignore_for_file: use_build_context_synchronously
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:nutrient_flutter/nutrient_flutter.dart';
+import 'utils/platform_utils.dart';
+import 'widgets/pdf_viewer_scaffold.dart';
+
+/// Example demonstrating how to use the hideDelete custom data to conditionally
+/// hide delete buttons on annotations in the PDF viewer.
+class HideDeleteAnnotationExampleWidget extends StatefulWidget {
+  final String documentPath;
+  final PdfConfiguration? configuration;
+
+  const HideDeleteAnnotationExampleWidget({
+    Key? key,
+    required this.documentPath,
+    this.configuration,
+  }) : super(key: key);
+
+  @override
+  State<HideDeleteAnnotationExampleWidget> createState() =>
+      _HideDeleteAnnotationExampleWidgetState();
+}
+
+class _HideDeleteAnnotationExampleWidgetState
+    extends State<HideDeleteAnnotationExampleWidget> {
+  late NutrientViewController view;
+  late PdfDocument? document;
+
+  @override
+  Widget build(BuildContext context) {
+    if (PlatformUtils.isCurrentPlatformSupported()) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Hide Delete Button Example'),
+        ),
+        body: Column(
+          children: [
+            // Control buttons at the top
+            Container(
+              padding: const EdgeInsets.all(16.0),
+              color: Colors.grey[100],
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: _addProtectedAnnotations,
+                      child: const Text('Add Protected'),
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: _addEditableAnnotations,
+                      child: const Text('Add Editable'),
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: _clearAllAnnotations,
+                      child: const Text('Clear All'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            // PDF viewer
+            Expanded(
+              child: PdfViewerScaffold(
+                documentPath: widget.documentPath,
+                configuration: widget.configuration,
+                onPdfDocumentLoaded: (document) {
+                  setState(() {
+                    this.document = document;
+                  });
+                },
+                onNutrientWidgetCreated: (controller) {
+                  view = controller;
+                },
+              ),
+            ),
+          ],
+        ),
+      );
+    } else {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Hide Delete Button Example')),
+        body: Center(
+          child: Text(
+            '$defaultTargetPlatform is not yet supported by PSPDFKit for Flutter.',
+          ),
+        ),
+      );
+    }
+  }
+
+  /// Adds annotations with hideDelete: true custom data
+  /// These annotations will not show a delete button in their contextual menu
+  Future<void> _addProtectedAnnotations() async {
+    final protectedAnnotations = [
+      // Protected highlight annotation - delete button will be hidden
+      HighlightAnnotation(
+        id: 'protected-highlight-1',
+        name: 'Protected Highlight',
+        bbox: [50.0, 400.0, 300.0, 20.0],
+        createdAt: DateTime.now().toIso8601String(),
+        color: const Color(0xFFFFEB3B),
+        rects: [
+          [50.0, 400.0, 350.0, 420.0],
+        ],
+        opacity: 0.7,
+        pageIndex: 0,
+        creatorName: 'System',
+        customData: {
+          'hideDelete': 'true', // This will hide the delete button
+          'protected': 'true',
+          'reason': 'System generated annotation',
+        },
+      ),
+
+      // Protected note annotation - delete button will be hidden
+      NoteAnnotation(
+        id: 'protected-note-1',
+        name: 'Protected Note',
+        bbox: [400.0, 400.0, 32.0, 32.0],
+        createdAt: DateTime.now().toIso8601String(),
+        text: TextContent(
+          value: 'This is a protected note that cannot be deleted',
+          format: TextFormat.plain,
+        ),
+        color: const Color(0xFFFF5722),
+        pageIndex: 0,
+        creatorName: 'Administrator',
+        customData: {
+          'hideDelete': true, // Boolean value also works
+          'protected': true,
+          'adminGenerated': true,
+        },
+      ),
+
+      // Protected free text annotation - delete button will be hidden
+      FreeTextAnnotation(
+        id: 'protected-freetext-1',
+        name: 'Protected Free Text',
+        bbox: [50.0, 500.0, 200.0, 50.0],
+        createdAt: DateTime.now().toIso8601String(),
+        text: TextContent(
+          format: TextFormat.plain,
+          value: 'PROTECTED CONTENT',
+        ),
+        fontColor: const Color(0xFFFFFFFF),
+        fontSize: 16,
+        font: 'sans-serif',
+        pageIndex: 0,
+        creatorName: 'System',
+        backgroundColor: const Color(0xFFFF5722),
+        horizontalTextAlign: HorizontalTextAlignment.center,
+        verticalAlign: VerticalAlignment.center,
+        customData: {
+          'hideDelete': 'true',
+          'systemGenerated': true,
+          'importance': 'high',
+        },
+      ),
+    ];
+
+    await document?.addAnnotations(protectedAnnotations);
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+              'Protected annotations added! Try to select them - no delete button will appear.'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+    }
+  }
+
+  /// Adds normal annotations without hideDelete custom data
+  /// These annotations will show the delete button normally
+  Future<void> _addEditableAnnotations() async {
+    final editableAnnotations = [
+      // Normal highlight annotation - delete button will be visible
+      HighlightAnnotation(
+        id: 'editable-highlight-1',
+        name: 'Editable Highlight',
+        bbox: [50.0, 300.0, 300.0, 20.0],
+        createdAt: DateTime.now().toIso8601String(),
+        color: const Color(0xFF4CAF50),
+        rects: [
+          [50.0, 300.0, 350.0, 320.0],
+        ],
+        opacity: 0.7,
+        pageIndex: 0,
+        creatorName: 'User',
+        customData: {
+          'editable': true,
+          'userGenerated': true,
+          // Note: no hideDelete property, so delete button will be visible
+        },
+      ),
+
+      // Normal note annotation - delete button will be visible
+      NoteAnnotation(
+        id: 'editable-note-1',
+        name: 'Editable Note',
+        bbox: [400.0, 300.0, 32.0, 32.0],
+        createdAt: DateTime.now().toIso8601String(),
+        text: TextContent(
+          value: 'This note can be deleted normally',
+          format: TextFormat.plain,
+        ),
+        color: const Color(0xFF2196F3),
+        pageIndex: 0,
+        creatorName: 'User',
+        customData: {
+          'editable': true,
+          'userGenerated': true,
+          // hideDelete is not set, so delete button will appear
+        },
+      ),
+    ];
+
+    await document?.addAnnotations(editableAnnotations);
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+              'Editable annotations added! These will show the delete button.'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    }
+  }
+
+  /// Removes all annotations from the page
+  Future<void> _clearAllAnnotations() async {
+    try {
+      final annotations = await document?.getAnnotations(0, AnnotationType.all);
+      if (annotations == null) return;
+
+      for (var annotation in annotations) {
+        await document?.removeAnnotation(annotation);
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('All annotations cleared!'),
+            backgroundColor: Colors.grey,
+          ),
+        );
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('Error clearing annotations: $e');
+      }
+    }
+  }
+}

--- a/example/lib/hide_delete_annotation_example.dart
+++ b/example/lib/hide_delete_annotation_example.dart
@@ -166,6 +166,7 @@ class _HideDeleteAnnotationExampleWidgetState
         ),
         color: const Color(0xFFFF5722),
         pageIndex: 0,
+        flags: [AnnotationFlag.lockedContents],
         creatorName: 'Administrator',
         customData: {
           'hideDelete': true, // Boolean value also works - disables contextual menu and resizing  
@@ -192,13 +193,48 @@ class _HideDeleteAnnotationExampleWidgetState
         backgroundColor: const Color(0xFFFF5722),
         horizontalTextAlign: HorizontalTextAlignment.center,
         verticalAlign: VerticalAlignment.center,
+        flags: [AnnotationFlag.lockedContents],
         customData: {
           'hideDelete': 'true',
           'systemGenerated': true,
           'importance': 'high',
         },
       ),
-
+      InkAnnotation(
+          id: 'ink-annotation-1',
+          bbox: [267.4, 335.1, 97.2, 10.3],
+          createdAt: '2025-01-06T16:36:59+03:00',
+          lines: InkLines(
+            points: [
+              [
+                [269.4, 343.4],
+                [308.4, 341.7],
+                [341.2, 339.6],
+                [358.8, 339.6],
+                [360.9, 339.2],
+                [362.6, 338.8],
+                [361.7, 337.1],
+              ]
+            ],
+            intensities: [
+              [1.0, 0.43, 0.64, 0.83, 0.98, 0.99, 0.97]
+            ],
+          ),
+          lineWidth: 4,
+          opacity: 1.0,
+          flags: [AnnotationFlag.lockedContents],
+          creatorName: 'Nutrient Flutter',
+          name: 'Ink annotation 1',
+          isDrawnNaturally: false,
+          strokeColor: const Color(0xFFFF5722),
+          customData: {
+            "phone": "123-456-7890",
+            "email": "3XZ5y@example.com",
+            "address": "123 Main St, Anytown, USA 12345",
+            "hideDelete": true,
+            "userGenerated": true
+          },
+          pageIndex: 0)
     ];
 
     await document?.addAnnotations(protectedAnnotations);

--- a/example/lib/hide_delete_annotation_example.dart
+++ b/example/lib/hide_delete_annotation_example.dart
@@ -15,7 +15,16 @@ import 'utils/platform_utils.dart';
 import 'widgets/pdf_viewer_scaffold.dart';
 
 /// Example demonstrating how to use the hideDelete custom data to conditionally
-/// hide delete buttons on annotations in the PDF viewer.
+/// hide all annotation modification options in the PDF viewer.
+/// 
+/// This example shows how to create "protected" annotations that cannot be modified
+/// by users. When annotations have 'hideDelete': true in their customData, all
+/// modification actions are hidden from contextual menus.
+/// 
+/// References:
+/// - Annotation Custom Data: https://www.nutrient.io/guides/flutter/annotations/annotation-json/
+/// - Android Menu Customization: https://www.nutrient.io/guides/android/customizing-the-interface/customizing-the-toolbar/
+/// - iOS Menu Customization: https://www.nutrient.io/guides/ios/customizing-the-interface/customizing-menus/
 class HideDeleteAnnotationExampleWidget extends StatefulWidget {
   final String documentPath;
   final PdfConfiguration? configuration;
@@ -41,7 +50,7 @@ class _HideDeleteAnnotationExampleWidgetState
     if (PlatformUtils.isCurrentPlatformSupported()) {
       return Scaffold(
         appBar: AppBar(
-          title: const Text('Hide Delete Button Example'),
+          title: const Text('Hide Annotation Modification Example'),
         ),
         body: Column(
           children: [
@@ -95,7 +104,7 @@ class _HideDeleteAnnotationExampleWidgetState
       );
     } else {
       return Scaffold(
-        appBar: AppBar(title: const Text('Hide Delete Button Example')),
+        appBar: AppBar(title: const Text('Hide Annotation Modification Example')),
         body: Center(
           child: Text(
             '$defaultTargetPlatform is not yet supported by PSPDFKit for Flutter.',
@@ -106,7 +115,13 @@ class _HideDeleteAnnotationExampleWidgetState
   }
 
   /// Adds annotations with hideDelete: true custom data
-  /// These annotations will not show a delete button in their contextual menu
+  /// These annotations will not show any modification options (delete, edit, copy, cut, style picker, etc.) in their contextual menu
+  /// 
+  /// The hideDelete property can be set as:
+  /// - String: 'hideDelete': 'true'
+  /// - Boolean: 'hideDelete': true
+  /// 
+  /// Reference: https://www.nutrient.io/guides/flutter/annotations/annotation-json/
   Future<void> _addProtectedAnnotations() async {
     final protectedAnnotations = [
       // Protected highlight annotation - delete button will be hidden
@@ -123,9 +138,9 @@ class _HideDeleteAnnotationExampleWidgetState
         pageIndex: 0,
         creatorName: 'System',
         customData: {
-          'hideDelete': 'true', // This will hide the delete button
-          'protected': 'true',
-          'reason': 'System generated annotation',
+          'hideDelete': 'true', // This will hide all modification options (delete, edit, copy, cut, style picker, etc.)
+          'protected': 'true',  // Additional custom property for application logic
+          'reason': 'System generated annotation', // Additional metadata
         },
       ),
 
@@ -143,9 +158,9 @@ class _HideDeleteAnnotationExampleWidgetState
         pageIndex: 0,
         creatorName: 'Administrator',
         customData: {
-          'hideDelete': true, // Boolean value also works
-          'protected': true,
-          'adminGenerated': true,
+          'hideDelete': true, // Boolean value also works - hides all modification options  
+          'protected': true,  // Additional custom property for application logic
+          'adminGenerated': true, // Additional metadata
         },
       ),
 
@@ -181,7 +196,7 @@ class _HideDeleteAnnotationExampleWidgetState
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text(
-              'Protected annotations added! Try to select them - no delete button will appear.'),
+              'Protected annotations added! Try to select them - no modification options will appear.'),
           backgroundColor: Colors.orange,
         ),
       );
@@ -189,7 +204,16 @@ class _HideDeleteAnnotationExampleWidgetState
   }
 
   /// Adds normal annotations without hideDelete custom data
-  /// These annotations will show the delete button normally
+  /// These annotations will show all modification options normally in their contextual menu
+  /// 
+  /// When hideDelete is not present or set to false, users can:
+  /// - Delete annotations
+  /// - Edit annotation content and properties  
+  /// - Copy/cut annotations
+  /// - Access style picker and inspector
+  /// - Group/ungroup annotations
+  /// 
+  /// Reference: https://www.nutrient.io/guides/flutter/annotations/annotation-json/
   Future<void> _addEditableAnnotations() async {
     final editableAnnotations = [
       // Normal highlight annotation - delete button will be visible
@@ -208,7 +232,7 @@ class _HideDeleteAnnotationExampleWidgetState
         customData: {
           'editable': true,
           'userGenerated': true,
-          // Note: no hideDelete property, so delete button will be visible
+          // Note: no hideDelete property, so all modification options will be visible
         },
       ),
 
@@ -228,7 +252,7 @@ class _HideDeleteAnnotationExampleWidgetState
         customData: {
           'editable': true,
           'userGenerated': true,
-          // hideDelete is not set, so delete button will appear
+          // hideDelete is not set, so all modification options will appear
         },
       ),
     ];
@@ -239,7 +263,7 @@ class _HideDeleteAnnotationExampleWidgetState
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text(
-              'Editable annotations added! These will show the delete button.'),
+              'Editable annotations added! These will show all modification options.'),
           backgroundColor: Colors.green,
         ),
       );

--- a/example/lib/hide_delete_annotation_example.dart
+++ b/example/lib/hide_delete_annotation_example.dart
@@ -14,12 +14,15 @@ import 'package:nutrient_flutter/nutrient_flutter.dart';
 import 'utils/platform_utils.dart';
 import 'widgets/pdf_viewer_scaffold.dart';
 
-/// Example demonstrating how to use the hideDelete custom data to conditionally
-/// hide all annotation modification options in the PDF viewer.
+/// Example demonstrating how to use the hideDelete custom data to disable
+/// annotation editing while still allowing movement.
 /// 
-/// This example shows how to create "protected" annotations that cannot be modified
-/// by users. When annotations have 'hideDelete': true in their customData, all
-/// modification actions are hidden from contextual menus.
+/// This example shows how to create "protected" annotations that can be moved but not
+/// edited or resized. When annotations have 'hideDelete': true in their customData:
+/// - The contextual toolbar/menu is completely disabled
+/// - Annotation resizing is blocked
+/// - Annotation movement is still allowed
+/// - All modification actions (delete, edit, copy, cut, style picker, etc.) are prevented
 /// 
 /// References:
 /// - Annotation Custom Data: https://www.nutrient.io/guides/flutter/annotations/annotation-json/
@@ -50,7 +53,7 @@ class _HideDeleteAnnotationExampleWidgetState
     if (PlatformUtils.isCurrentPlatformSupported()) {
       return Scaffold(
         appBar: AppBar(
-          title: const Text('Hide Annotation Modification Example'),
+          title: const Text('Protected Annotations (Move Only)'),
         ),
         body: Column(
           children: [
@@ -115,16 +118,23 @@ class _HideDeleteAnnotationExampleWidgetState
   }
 
   /// Adds annotations with hideDelete: true custom data
-  /// These annotations will not show any modification options (delete, edit, copy, cut, style picker, etc.) in their contextual menu
+  /// These annotations will have their contextual toolbar/menu completely disabled and cannot be resized,
+  /// but can still be moved around the page.
+  /// 
+  /// Behavior for protected annotations:
+  /// - No contextual toolbar/menu appears when selected
+  /// - Cannot be resized (handles are disabled)
+  /// - Can still be moved by dragging
+  /// - Cannot be deleted, edited, copied, cut, styled, etc.
   /// 
   /// The hideDelete property can be set as:
-  /// - String: 'hideDelete': 'true'
+  /// - String: 'hideDelete': 'true' 
   /// - Boolean: 'hideDelete': true
   /// 
   /// Reference: https://www.nutrient.io/guides/flutter/annotations/annotation-json/
   Future<void> _addProtectedAnnotations() async {
     final protectedAnnotations = [
-      // Protected highlight annotation - delete button will be hidden
+      // Protected highlight annotation - contextual menu disabled, resizing blocked, movement allowed
       HighlightAnnotation(
         id: 'protected-highlight-1',
         name: 'Protected Highlight',
@@ -138,13 +148,13 @@ class _HideDeleteAnnotationExampleWidgetState
         pageIndex: 0,
         creatorName: 'System',
         customData: {
-          'hideDelete': 'true', // This will hide all modification options (delete, edit, copy, cut, style picker, etc.)
+          'hideDelete': 'true', // This will disable contextual menu and resizing, but allow movement
           'protected': 'true',  // Additional custom property for application logic
           'reason': 'System generated annotation', // Additional metadata
         },
       ),
 
-      // Protected note annotation - delete button will be hidden
+      // Protected note annotation - contextual menu disabled, resizing blocked, movement allowed
       NoteAnnotation(
         id: 'protected-note-1',
         name: 'Protected Note',
@@ -158,13 +168,13 @@ class _HideDeleteAnnotationExampleWidgetState
         pageIndex: 0,
         creatorName: 'Administrator',
         customData: {
-          'hideDelete': true, // Boolean value also works - hides all modification options  
+          'hideDelete': true, // Boolean value also works - disables contextual menu and resizing  
           'protected': true,  // Additional custom property for application logic
           'adminGenerated': true, // Additional metadata
         },
       ),
 
-      // Protected free text annotation - delete button will be hidden
+      // Protected free text annotation - contextual menu disabled, resizing blocked, movement allowed
       FreeTextAnnotation(
         id: 'protected-freetext-1',
         name: 'Protected Free Text',
@@ -188,6 +198,7 @@ class _HideDeleteAnnotationExampleWidgetState
           'importance': 'high',
         },
       ),
+
     ];
 
     await document?.addAnnotations(protectedAnnotations);
@@ -196,7 +207,7 @@ class _HideDeleteAnnotationExampleWidgetState
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text(
-              'Protected annotations added! Try to select them - no modification options will appear.'),
+              'Protected annotations added! Try selecting them - no contextual menu will appear, but you can still move them.'),
           backgroundColor: Colors.orange,
         ),
       );
@@ -204,7 +215,7 @@ class _HideDeleteAnnotationExampleWidgetState
   }
 
   /// Adds normal annotations without hideDelete custom data
-  /// These annotations will show all modification options normally in their contextual menu
+  /// These annotations will show the full contextual toolbar/menu with all modification options
   /// 
   /// When hideDelete is not present or set to false, users can:
   /// - Delete annotations
@@ -212,11 +223,13 @@ class _HideDeleteAnnotationExampleWidgetState
   /// - Copy/cut annotations
   /// - Access style picker and inspector
   /// - Group/ungroup annotations
+  /// - Resize annotations using handles
+  /// - Move annotations by dragging
   /// 
   /// Reference: https://www.nutrient.io/guides/flutter/annotations/annotation-json/
   Future<void> _addEditableAnnotations() async {
     final editableAnnotations = [
-      // Normal highlight annotation - delete button will be visible
+      // Normal highlight annotation - full contextual menu available
       HighlightAnnotation(
         id: 'editable-highlight-1',
         name: 'Editable Highlight',
@@ -236,7 +249,7 @@ class _HideDeleteAnnotationExampleWidgetState
         },
       ),
 
-      // Normal note annotation - delete button will be visible
+      // Normal note annotation - full contextual menu available
       NoteAnnotation(
         id: 'editable-note-1',
         name: 'Editable Note',
@@ -252,9 +265,10 @@ class _HideDeleteAnnotationExampleWidgetState
         customData: {
           'editable': true,
           'userGenerated': true,
-          // hideDelete is not set, so all modification options will appear
+          // hideDelete is not set, so full contextual menu will appear
         },
       ),
+
     ];
 
     await document?.addAnnotations(editableAnnotations);
@@ -263,7 +277,7 @@ class _HideDeleteAnnotationExampleWidgetState
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text(
-              'Editable annotations added! These will show all modification options.'),
+              'Editable annotations added! These will show the full contextual menu with all editing options.'),
           backgroundColor: Colors.green,
         ),
       );

--- a/ios/Classes/ProtectedResizableView.swift
+++ b/ios/Classes/ProtectedResizableView.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright © 2024-2025 PSPDFKit GmbH. All rights reserved.
+//
+//  THIS SOURCE CODE AND ANY ACCOMPANYING DOCUMENTATION ARE PROTECTED BY INTERNATIONAL COPYRIGHT LAW
+//  AND MAY NOT BE RESOLD OR REDISTRIBUTED. USAGE IS BOUND TO THE PSPDFKIT LICENSE AGREEMENT.
+//  UNAUTHORIZED REPRODUCTION OR DISTRIBUTION IS SUBJECT TO CIVIL AND CRIMINAL PENALTIES.
+//  This notice may not be removed from this file.
+//
+
+import Foundation
+import PSPDFKit
+
+/// Custom ResizableView that can be controlled externally to disable resizing for protected annotations
+/// 
+/// This class allows dynamic control of annotation resizing based on the `resizingEnabled` static property.
+/// When `resizingEnabled` is set to false, annotations will not show resize handles and cannot be resized.
+/// This is used in conjunction with annotation selection delegates to disable resizing for annotations
+/// that have 'hideDelete': true in their customData.
+///
+/// Usage:
+/// ```
+/// // Disable resizing for protected annotations
+/// ProtectedResizableView.resizingEnabled = false
+/// 
+/// // Re-enable resizing for normal annotations
+/// ProtectedResizableView.resizingEnabled = true
+/// ```
+///
+/// References:
+/// - PSPDFKit ResizableView: https://www.nutrient.io/api/ios/documentation/pspdfkitui/resizableview
+/// - Class Override Guide: https://www.nutrient.io/guides/ios/getting-started/overriding-classes/
+@objc public class ProtectedResizableView: ResizableView{
+    /// Static property to control resizing globally for all ProtectedResizableView instances
+    /// Set to false to disable resizing for protected annotations, true to enable resizing
+    static var resizingEnabled: Bool = true
+    
+    /// Override the allowResizing property to return our static control value
+    public override var allowResizing: Bool {
+        get {
+            return ProtectedResizableView.resizingEnabled
+        }
+        set {
+            // Do nothing - controlled by static property
+            // This prevents external code from directly setting allowResizing
+        }
+    }
+    
+    public override var allowRotating: Bool {
+        get {
+            return ProtectedResizableView.resizingEnabled
+        }
+        set {
+            // Do nothing - controlled by static property
+            // This prevents external code from directly setting allowRotating
+        }
+    }
+}

--- a/ios/Classes/PspdfPlatformView.m
+++ b/ios/Classes/PspdfPlatformView.m
@@ -73,6 +73,12 @@
             BOOL isImageDocument = [PspdfkitFlutterHelper isImageDocument:documentPath];
             PSPDFConfiguration *configuration = [PspdfkitFlutterConverter configuration:configurationDictionary isImageDocument:isImageDocument];
             
+            
+            //Override PSPDFResizableView with ProtectedResizableView to disable text selection handles
+            configuration = [configuration configurationUpdatedWithBuilder:^(PSPDFConfigurationBuilder *builder) {
+                [builder overrideClass:PSPDFResizableView.class withClass:ProtectedResizableView.class];
+            }];
+            
             // Only update signature settings if signatureSavingStrategy is specified in the configuration
             if (configurationDictionary[@"signatureSavingStrategy"]) {
                 PSPDFConfiguration *updatedConfig = [configuration configurationUpdatedWithBuilder:^(PSPDFConfigurationBuilder *builder) {

--- a/ios/Classes/PspdfkitPlatformViewImpl.swift
+++ b/ios/Classes/PspdfkitPlatformViewImpl.swift
@@ -137,6 +137,7 @@ public class PspdfkitPlatformViewImpl: NSObject, NutrientViewControllerApi, PDFV
                                onPageView pageView: PDFPageView,
                                appearance: EditMenuAppearance,
                                suggestedMenu: UIMenu) -> UIMenu {
+        ProtectedResizableView.resizingEnabled = false
         print("*** menuForAnnotations delegate method called! Annotations count: \(annotations.count)")
         
         // Check if editing should be disabled based on annotation custom data
@@ -146,6 +147,7 @@ public class PspdfkitPlatformViewImpl: NSObject, NutrientViewControllerApi, PDFV
             print("*** Disabling context menu entirely for protected annotations")
             // Return an empty menu to completely disable the context menu
             // This allows annotations to remain selectable and movable but prevents all editing actions
+            ProtectedResizableView.resizingEnabled = false
             return UIMenu(title: "", children: [])
         }
         


### PR DESCRIPTION
This pull request introduces a new feature that allows conditional hiding of the delete button for PDF annotations based on custom data. The implementation covers both Android and iOS platforms, and a new Flutter example demonstrates how to use this feature. The changes include UI logic, platform-specific implementations, and an example for users.

**Feature: Hide Delete Button on Annotations**

*Android Implementation:*
- Added logic in `FlutterPdfUiFragment` to check annotation custom data for a `hideDelete` property and hide the delete button in the contextual toolbar if present. [[1]](diffhunk://#diff-b19649640a168830b3afe387a629bf5dcd936ca8d6d863e7585ca559359a92ffR33-R47) [[2]](diffhunk://#diff-b19649640a168830b3afe387a629bf5dcd936ca8d6d863e7585ca559359a92ffR69-R73) [[3]](diffhunk://#diff-b19649640a168830b3afe387a629bf5dcd936ca8d6d863e7585ca559359a92ffR314-R368)

*iOS Implementation:*
- Implemented delegate methods in `PspdfkitPlatformViewImpl` to filter out the delete action from the annotation menu based on the `hideDelete` custom data property.

*Flutter Example:*
- Added a new example (`hide_delete_annotation_example.dart`) that demonstrates adding protected (non-deletable) and editable (deletable) annotations, and shows how the delete button is conditionally displayed.
- Registered the new example in the app's example list and navigation logic. [[1]](diffhunk://#diff-f9e42f4519a3f2dc5f97154ba02c377a0f055b93dd97ec6b4d837a391333a3b2R45) [[2]](diffhunk://#diff-f9e42f4519a3f2dc5f97154ba02c377a0f055b93dd97ec6b4d837a391333a3b2R114-R119) [[3]](diffhunk://#diff-f9e42f4519a3f2dc5f97154ba02c377a0f055b93dd97ec6b4d837a391333a3b2R624-R630)